### PR TITLE
fix compat with extract-text-webpack-plugin 2.0 rc

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -138,12 +138,23 @@ module.exports = function (content) {
     })
   }
 
+  function stringifyLoaders (loaders) {
+    return loaders.map(function(obj) {
+      return obj && typeof obj === 'object' && typeof obj.loader === 'string'
+        ? obj.loader + (obj.options ? '?' + JSON.stringify(obj.options) : '')
+        : obj
+    }).join('!');
+  }
+
   function getLoaderString (type, part, index, scoped) {
     var lang = part.lang || defaultLang[type]
     var loader = loaders[lang]
     var rewriter = type === 'styles' ? styleRewriter + (scoped ? '&scoped=true!' : '!') : ''
     var injectString = (type === 'script' && query.inject) ? 'inject!' : ''
     if (loader !== undefined) {
+      if (Array.isArray(loader)) {
+        loader = stringifyLoaders(loader);
+      }
       // add css modules
       if (type === 'styles') {
         loader = addCssModulesToLoader(loader, part, index)


### PR DESCRIPTION
Recently I found an issue when using current version of `weex-vue-loader` with `webpack`@`2.2.1` and `extract-text-webpack-plugin`@`2.0.0-rc.2`. The error was:

```
ERROR in ./src/App.vue
Module build failed: TypeError: loader.charAt is not a function
    at ensureBang (.0.2.11@weex-vue-loader/lib/loader.js:204:16)
    at getLoaderString (.0.2.11@weex-vue-loader/lib/loader.js:16
9:18)
    at getRequireString (.0.2.11@weex-vue-loader/lib/loader.js:9
3:7)
    at getRequire (.0.2.11@weex-vue-loader/lib/loader.js:84:7)
    at .0.2.11@weex-vue-loader/lib/loader.js:234:11
    at Array.forEach (native)
    at Object.module.exports (.0.2.11@weex-vue-loader/lib/loader
.js:223:18)
    at Object.loader (.0.4.4@weex-loader/lib/loader.js:228:36)
 @ ./src/main.js 2:0-24
```

I tried to debug weex-vue-loader and found this was because weex-vue-loader was expecting a string while the new version of extract text plugin returned an array.

I also found this issue was reported in vue-loader [#594](https://github.com/vuejs/vue-loader/issues/594). So I submitted this PR according to this [commit](https://github.com/vuejs/vue-loader/commit/c6fc82f7e713d23f84641179692d233f6419cb94).