### PR TITLE
use relative path to generate scope id instead of absolute path

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -56,7 +56,7 @@ module.exports = function (content) {
   var options = this.options.__vueOptions__ = Object.assign({}, this.options.vue, this.vue, query)
   var filePath = this.resourcePath
   var fileName = path.basename(filePath)
-  var moduleId = 'data-v-' + genId(filePath)
+  var moduleId = 'data-v-' + genId(path.relative(process.cwd(), filePath))
   var styleRewriter = styleRewriterPath + '?id=' + moduleId
 
   var isProduction = this.minimize || process.env.NODE_ENV === 'production'


### PR DESCRIPTION
use relative path to generate scope id instead of absolute path