### PR TITLE
upgrade weex-tempalte-compiler to 2.5.11-weex.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5751,9 +5751,9 @@
       "integrity": "sha512-+zVcQO27iIh5rwGwvpbJKsFN3rciRRiRwXZDYRvzoHBzooCvtCf3tj0FtMtz9v1Z0IlGn/WH3m/Y0SocUdO/jQ=="
     },
     "weex-template-compiler": {
-      "version": "2.5.4-weex.0",
-      "resolved": "https://registry.npmjs.org/weex-template-compiler/-/weex-template-compiler-2.5.4-weex.0.tgz",
-      "integrity": "sha512-Dsn1V29ZN3UcEJqH3JIgaGEZgSI2TD6jrBEyYO8slVpHifBBd8lKe7HHrKhsux360VMtuKof+ilYKSOl9+jxjA=="
+      "version": "2.5.11-weex.0",
+      "resolved": "https://registry.npmjs.org/weex-template-compiler/-/weex-template-compiler-2.5.11-weex.0.tgz",
+      "integrity": "sha512-2M8leSk+xHoqHDH0qLDHCMYnaX+QPQiVDJ6PPb5itVNQstXa2B/ywaMFxNnReGMeJ2UW03jvnryce9aQNqujbw=="
     },
     "whatwg-encoding": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vue-template-compiler": "^2.5.4",
     "vue-template-es2015-compiler": "^1.2.2",
     "weex-styler": "^0.3.0",
-    "weex-template-compiler": "^2.5.4-weex.0"
+    "weex-template-compiler": "^2.5.11-weex.0"
   },
   "peerDependencies": {
     "css-loader": "*"


### PR DESCRIPTION
Support to compile the new syntax on <recycle-list>. https://github.com/vuejs/vue/commit/7cc0b559e9e57fcb3baeae5d8d4c8964aa335b5e