### PR TITLE
support register scoped style sheets for each component

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -353,9 +353,11 @@ module.exports = function (content) {
   '  }\n' +
   '})\n'
 
-  // support to register static styles
-  exports += 'if (typeof __register_static_styles__ === "function") {\n' +
-  '  __register_static_styles__(__vue_options__._scopeId, __vue_styles__)\n' +
+  // support to register style sheets
+  exports += 'if (typeof weex === "object" && weex && weex.document) {\n' +
+  '  try {\n' +
+  '    weex.document.registerStyleSheets(__vue_options__._scopeId, __vue_styles__)\n' +
+  '  } catch (e) {}\n' +
   '}\n'
 
   if (!query.inject) {


### PR DESCRIPTION
Generate `scopeId` for each style sheet, and inject a code snippet to process them at the definition of each component.

```js
if (typeof weex === 'object' && weex && weex.document) {
  // process style sheets here
  try {
    weex.document.registerStyleSheets(scopeId, styleSheets)
  } catch (e) {}
}
```

Refer to https://github.com/Hanks10100/weex-native-directive/issues/14#issuecomment-354404107