### PR TITLE
feat: enable the loaders chain

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -50,6 +50,18 @@ function hasRecyclable (template) {
   return !!(template && template.attrs && template.attrs.recyclable)
 }
 
+// When extracting parts from the source vue file, we want to apply the
+// loaders chained before vue-loader, but exclude some loaders that simply
+// produces side effects such as linting.
+function getRawRequest (context, excludedPreLoaders) {
+  excludedPreLoaders = excludedPreLoaders || /eslint-loader/
+  return loaderUtils.getRemainingRequest({
+    resource: context.resource,
+    loaderIndex: context.loaderIndex,
+    loaders: context.loaders.filter(loader => !excludedPreLoaders.test(loader.path))
+  })
+}
+
 module.exports = function (content) {
   this.cacheable()
   // var isServer = this.options.target === 'node'
@@ -59,6 +71,7 @@ module.exports = function (content) {
   var params = this.resourceQuery && loaderUtils.parseQuery(this.resourceQuery)
   var options = this.options.__vueOptions__ = Object.assign({}, this.options.vue, this.vue, query)
   var filePath = this.resourcePath
+  var rawRequest = getRawRequest(this, options.excludedPreLoaders)
   var fileName = path.basename(filePath)
   var moduleId = 'data-v-' + genId(path.relative(process.cwd(), filePath))
   var styleRewriter = styleRewriterPath + '?id=' + moduleId
@@ -97,8 +110,8 @@ module.exports = function (content) {
       getLoaderString(type, part, index, scoped) +
       // select the corresponding part from the vue file
       getSelectorString(type, index || 0) +
-      // the url to the actual vuefile
-      filePath
+      // the url to the actual vuefile including remaining requests
+      rawRequest
     )
   }
 
@@ -161,7 +174,6 @@ module.exports = function (content) {
       }
       // add css modules
       if (type === 'styles') {
-
         loader = addCssModulesToLoader(loader, part, index)
         // while lang existed, the `style-loader` is also needed.
         if (lang && Array.isArray(loaders[lang])) {


### PR DESCRIPTION
I wrote a loader for my project before weex-loader(failed) and vue loader(success), my `webpack.config.js` like:

```
module: {
  rules: [
    {
      test: /\.vue$/,
      use: [
        isWeeb ? 'vue-loader' : 'weex-loader',
        'my-loader'  // my loader here
      ]
    }
  ]
}
```

Failed to work in `weex-loader`, I found the reason from vue loader: [vue-loader#loader.js](https://github.com/vuejs/vue-loader/blob/v12/lib/loader.js#L36), and `weex-vue-loader` use `filePath` but not `rawRequest`.

```
// before
require("!!weex-loader/node_modules/weex-vue-loader/lib/style-loader!weex-loader/node_modules/weex-vue-loader/lib/style-rewriter?id=data-v-cf012960!weex-loader/node_modules/weex-vue-loader/lib/selector?type=styles&index=0!./index.vue"

// after
require("!!weex-loader/node_modules/weex-vue-loader/lib/style-loader!weex-loader/node_modules/weex-vue-loader/lib/style-rewriter?id=data-v-cf012960!weex-loader/node_modules/weex-vue-loader/lib/selector?type=styles&index=0!../../common/myLoader.js??ref--1-0!./index.vue"
```

It will apply the loaders chained before weex-vue-loader