### PR TITLE
add compiler options feat

### DIFF
--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -68,9 +68,14 @@ module.exports = function (html) {
   // var compiled = compiler.compile(html, Object.assign({
   //   preserveWhitespace: vueOptions.preserveWhitespace
   // }, defaultCompileOptions))
-  var compiled = compiler.compile(html, {
-    recyclable: query.recyclable
-  })
+
+  var options = {recyclable: query.recyclable}
+  if (vueOptions) {
+    if (vueOptions.compilerOptions) {
+      Object.assign(options, vueOptions.compilerOptions)
+    }
+  }
+  var compiled = compiler.compile(html, options)
   var code
   if (compiled.errors.length) {
     var self = this


### PR DESCRIPTION
usage is as follows:

```
{
  test: /\.vue(\?[^?]+)?$/,
  loader: 'weex-loader',
  options: {
    compilerOptions: {
      modules: [{
        transformNode: (el, options) => {},
        preTransformNode: (el, options) => {},
        postTransformNode: (el, options) => {}
        }
      ]  
    }
  }
}
```
